### PR TITLE
ci: publish main image as :v1 instead of :latest

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,4 +11,4 @@ jobs:
     uses: ./.github/workflows/build-and-deploy.yml
     with:
       branch: main
-      tag: latest
+      tag: v1


### PR DESCRIPTION
## Что

В `.github/workflows/main.yml` меняю docker image tag `latest` → `v1`.

## Зачем

Сейчас версии деплоятся неявно: `main` → `:latest`, `v2_bug_fixes` → `:v2`. После правки в ghcr будут симметричные `:v1` / `:v2` — версии явно разделены.

## Заметки

- `build-and-deploy.yml` использует `inputs.tag` для `cache-from`/`cache-to`/`tags`, так что правки одной строки достаточно. На первом запуске `cache-from: ...:v1` даст cache-miss — это норма.
- Старый образ `:latest` останется в реестре, но перестанет обновляться. Если где-то прод тянет `:latest` — переключить на `:v1` (в репозитории `:latest` нигде не используется: `docker-compose.production.yml` собирает образ локально).

🤖 Generated with [Claude Code](https://claude.com/claude-code)